### PR TITLE
Collect cluster connectivity errors

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -71,8 +71,9 @@ sendClusterConnectivityErrorEvent() {
     getNs="$(kubectl get ns default -v6)"
     getPods="$(kubectl get pod -o wide -v6)"
 
-    properties="$(jq -nc --arg getNs "$getNs" --arg getPods "$getPods" --arg email "$USER_EMAIL" --arg origin "self-serve-script" --arg scriptType "bash" '$ARGS.named')"
-    data='{"eventName": "USER_CLUSTER_CONNECTIVITY_SUCCESS_ERROR","userId": "'$USER_EMAIL'","properties": '$properties'}'
+    properties='{"getPods": "'"$getPods"'", "getNs": "'"$getNs"'", "email": "'"$USER_EMAIL"'", "origin": "self-serve-script", "scriptType": "bash"}'
+
+    data='{"eventName": "ARIEL_TEST","userId": "'$USER_EMAIL'", "properties": '$properties'}'
 
     curl --location --request POST 'https://api.komodor.com/analytics/segment/track' \
         --header 'api-key: '$USER_EMAIL'' \
@@ -107,7 +108,7 @@ sendErrorAnalytics() {
     # argument 1 = The event name
     # argument 2 = The error message
 
-    properties="$(jq -nc --arg error "$2" --arg email "$USER_EMAIL" --arg origin "self-serve-script" --arg scriptType "bash" '$ARGS.named')"
+    properties='{"error": "'"$2"'", "email": "'"$USER_EMAIL"'", "origin": "self-serve-script", "scriptType": "bash"}'
     data='{"eventName": "'$1'","userId": "'$USER_EMAIL'","properties": '$properties'}'
 
     curl --location --request POST 'https://api.komodor.com/analytics/segment/track' \

--- a/install.sh
+++ b/install.sh
@@ -68,10 +68,10 @@ sendClusterConnectivityErrorEvent() {
     echo "$ kubectl get ns default -v6"
     echo "$ kubectl get pod -o wide -v6"
 
-    getNs="$(kubectl get ns default -v6)"
-    getPods="$(kubectl get pod -o wide -v6)"
+    getNsDefault="$(kubectl get ns default -v6)"
+    getAllNs="$(kubectl get ns -v6)"
 
-    properties='{"getPods": "'"$getPods"'", "getNs": "'"$getNs"'", "email": "'"$USER_EMAIL"'", "origin": "self-serve-script", "scriptType": "bash"}'
+    properties='{"getAllNs": "'"$getAllNs"'", "getNsDefault": "'"$getNs"'", "email": "'"$USER_EMAIL"'", "origin": "self-serve-script", "scriptType": "bash"}'
 
     data='{"eventName": "ARIEL_TEST","userId": "'$USER_EMAIL'", "properties": '$properties'}'
 

--- a/install.sh
+++ b/install.sh
@@ -61,6 +61,30 @@ printSuccess() {
     echo "Open https://app.komodor.com/ to start using Komodor"
 }
 
+sendClusterConnectivityErrorEvent() {
+    # We collect error logs to learn about and improve the installation process.
+
+    echo 'Running the following commands for troubleshooting and analytics:'
+    echo "$ kubectl get ns default -v6"
+    echo "$ kubectl get pod -o wide -v6"
+
+    getNs="$(kubectl get ns default -v6)"
+    getPods="$(kubectl get pod -o wide -v6)"
+
+    properties="$(jq -nc --arg getNs "$getNs" --arg getPods "$getPods" --arg email "$USER_EMAIL" --arg origin "self-serve-script" --arg scriptType "bash" '$ARGS.named')"
+    data='{"eventName": "USER_CLUSTER_CONNECTIVITY_SUCCESS_ERROR","userId": "'$USER_EMAIL'","properties": '$properties'}'
+
+    curl --location --request POST 'https://api.komodor.com/analytics/segment/track' \
+        --header 'api-key: '$USER_EMAIL'' \
+        --header 'Content-Type: application/json' \
+        -d @<(
+            cat <<EOF
+$data
+EOF
+        )
+
+}
+
 sendAnalytics() {
     # We use analytics to keep track of what works and what doesn't work in our script, with the intention of creating the best installation experience possible.
     # argument 1 = Event type
@@ -78,24 +102,23 @@ sendAnalytics() {
         }
     }'
 }
-
 sendErrorAnalytics() {
     # We collect error logs to learn about and improve the installation process.
-    # argument 1 = The error message
-    echo $2
+    # argument 1 = The event name
+    # argument 2 = The error message
+
+    properties="$(jq -nc --arg error "$2" --arg email "$USER_EMAIL" --arg origin "self-serve-script" --arg scriptType "bash" '$ARGS.named')"
+    data='{"eventName": "'$1'","userId": "'$USER_EMAIL'","properties": '$properties'}'
+
     curl --location --request POST 'https://api.komodor.com/analytics/segment/track' \
-        --header 'api-key: "'"$USER_EMAIL"'"' \
+        --header 'api-key: '$USER_EMAIL'' \
         --header 'Content-Type: application/json' \
-        --data-raw '{
-    "eventName": "'"$1"'",
-    "userId": "'"$USER_EMAIL"'",
-    "properties": {
-        "email": "'"$USER_EMAIL"'",
-        "origin": "self-serve-script",
-        "error": "'"$2"'",
-        "scriptType": "bash"
-    }
-}'
+        -d @<(
+            cat <<EOF
+$data
+EOF
+        )
+
 }
 
 STEPS_COUNT=6
@@ -202,9 +225,10 @@ checkKubectlRequirements() {
 }
 
 checkConnectionToCluster() {
-    printStep 3 "Checking Cluster Connection"
+    printStep 3 "Checking Cluster Connection with command: kubectl get ns default"
     if ! kubectl get ns default >/dev/null 2>&2; then
-        echo 'Kubernetes cluster connectivity test failed...' >&2
+        echo 'Kubernetes cluster connectivity test failed... please make sure your cluster is up and your context is correct.' >&2
+        sendClusterConnectivityErrorEvent
         exit 1
     fi
     echo 'Kubernetes cluster connectivity test success!'

--- a/install.sh
+++ b/install.sh
@@ -282,6 +282,7 @@ installKomodorHelmPackage() {
         sendAnalytics USER_INSTALL_KOMODOR_SCRIPT_SUCCESS
     else
         echo "Komodor install failed..."
+        echo "$INSTALL_OUTPUT"
         sendErrorAnalytics "USER_INSTALL_KOMODOR_SCRIPT_SUCCESS_ERROR" "$INSTALL_OUTPUT"
         exit 1
     fi

--- a/install.sh
+++ b/install.sh
@@ -66,7 +66,7 @@ sendClusterConnectivityErrorEvent() {
 
     echo 'Running the following commands for troubleshooting and analytics:'
     echo "$ kubectl get ns default -v6"
-    echo "$ kubectl get pod -o wide -v6"
+    echo "$ kubectl get ns -v6"
 
     getNsDefault="$(kubectl get ns default -v6)"
     getAllNs="$(kubectl get ns -v6)"


### PR DESCRIPTION
This pr introduces an event for an error in the cluster connectivity check step.
In case of failure of "kubectl get ns default" we log the output of "kubectl get ns -v6" 
