### PR TITLE
added choose context step

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -352,10 +352,10 @@ installKomodorHelmPackage() {
     kubectl config use-context $INITIAL_CONTEXT
 }
 
-# startExecuting            # step 1
-# checkKubectlRequirements  # step 2
-chooseContext            # step 3
-checkConnectionToCluster # step 4
-# setClusterName            # step 5
-# checkHelmRequirement      # step 6
-# installKomodorHelmPackage # step 7
+startExecuting            # step 1
+checkKubectlRequirements  # step 2
+chooseContext             # step 3
+checkConnectionToCluster  # step 4
+setClusterName            # step 5
+checkHelmRequirement      # step 6
+installKomodorHelmPackage # step 7

--- a/install.sh
+++ b/install.sh
@@ -349,6 +349,7 @@ installKomodorHelmPackage() {
     fi
     printSuccess
     # Make sure the user returns to the initial kube context
+    echo "Switching back to initial context:"
     kubectl config use-context $INITIAL_CONTEXT
 }
 

--- a/install.sh
+++ b/install.sh
@@ -335,7 +335,6 @@ installKomodorHelmPackage() {
         exit 1
     fi
     printSuccess
-    # Make sure the user returns to the initial kube context
 }
 
 startExecuting            # step 1


### PR DESCRIPTION
This pr introduces an extra step before checking cluster connectivity: choosing kube context.

after the user selects the desired context, we perform $kubectl config use-context ${chosen_context}, therefore we actually change the users context, which might be unwanted/confusing - which is why at the end of the scripts execution we restore the initial context with the new function : 'exitAndResetContext'