### PR TITLE
Report failed "helm repo add" into analytics

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -262,12 +262,14 @@ function installKomodorHelmPackage() {
     Write-Output "- $ helm repo add komodorio https://helm-charts.komodor.io"
     Write-Output "- $ helm repo update"
     Write-Output "- $ helm upgrade --install k8s-watcher komodorio/k8s-watcher --set watcher.actions.basic=true --set watcher.actions.advanced=true --set watcher.actions.podExec=true --set apiKey=$HELM_API_KEY --set watcher.clusterName=$FINAL_CLUSTER_NAME --wait --timeout=90s"
-    helm repo add komodorio https://helm-charts.komodor.io 2>$null | Out-Null
+    $INSTALL_OUTPUT = $( $output = & helm repo add komodorio https://helm-charts.komodor.io ) 2>&1
+    Write-Output "$INSTALL_OUTPUT"
     if ($LASTEXITCODE -eq 0) {
         Write-Output "Added komodor chart repository successfully!"
     }
     else {
         Write-Output "Failed adding komodor chart repository..."
+        sendErrorAnalytics "USER_INSTALL_KOMODOR_SCRIPT_SUCCESS_ERROR" "$INSTALL_OUTPUT"
         exit 1
     }
     Write-Output "Installing Komodor, this might take a minute"

--- a/install.sh
+++ b/install.sh
@@ -315,11 +315,13 @@ installKomodorHelmPackage() {
     echo "- $ helm repo add komodorio https://helm-charts.komodor.io"
     echo "- $ helm repo update"
     echo "- $ helm upgrade --install k8s-watcher komodorio/k8s-watcher --set watcher.actions.basic=true --set watcher.actions.advanced=true --set watcher.actions.podExec=true --set apiKey=$HELM_API_KEY --set watcher.clusterName=$FINAL_CLUSTER_NAME --wait --timeout=90s"
-    helm repo add komodorio https://helm-charts.komodor.io >/dev/null 2>&2
+    INSTALL_OUTPUT=$(helm repo add komodorio https://helm-charts.komodor.io 2>&1)
     if [ $? -eq 0 ]; then
         echo "Added komodor chart repository successfully!"
     else
         echo "Failed adding komodor chart repository..."
+        echo "$INSTALL_OUTPUT"
+        sendErrorAnalytics "USER_INSTALL_KOMODOR_SCRIPT_SUCCESS_ERROR" "$INSTALL_OUTPUT"
         exit 1
     fi
     echo "Installing Komodor, this might take a minute"


### PR DESCRIPTION
With Timi, we've found that a fraction of users never get to run "helm install" command, while passing Helm presence check. In the script, the "repo add" step was completely muted and the failure from it not reported. This PR fixes that.